### PR TITLE
Add systemd-coredump installation to ubuntu basic install

### DIFF
--- a/ansible/roles/os_config/tasks/install-ubuntu.yml
+++ b/ansible/roles/os_config/tasks/install-ubuntu.yml
@@ -12,6 +12,7 @@
       - iotop
       - openssh-server
       - ntp     
+      - systemd-coredump
      update_cache: yes
      install_recommends: no
      state: present


### PR DESCRIPTION
There is a need to install systemd-coredump for managing c++ coredumps